### PR TITLE
chore: fix link for hsf-training

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ repository for reference while revising.
 More information on how to contribute or how to contact us: [HSF training home][hsf-training]
 
 [hsf-training-issues]: https://github.com/issues?q=user%3Ahsf-training+is%3Aopen
-[hsf-training]: hepsoftwarefoundation.org/workinggroups/training.html
+[hsf-training]: https://hepsoftwarefoundation.org/workinggroups/training.html
 [email]: mailto:https://groups.google.com/forum/#!forum/hsf-training-wg
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/


### PR DESCRIPTION
Add `https://`