### PR TITLE
Title: docs: add physics callout box for Higgs search data distribution #127

### DIFF
--- a/_episodes/04-higgs-search.md
+++ b/_episodes/04-higgs-search.md
@@ -497,9 +497,11 @@ ax.legend(fontsize=18, frameon=False)
 
 ![m4lep_histogram_5]({{ page.root }}/fig/m4lep_histogram_5.png)
 
-> ## Physics Tip: The Higgs Signal
-> When looking at the invariant mass distribution, the peak at $125 \text{GeV}$  represents the reconstructed Higgs Boson.
-> **Data vs. MC:** The Black dots represent actual ATLAS experiment data, while the colored histograms are Monte Carlo (MC) Simulations. We compare them to see if our theoretical models match reality! {: .challenge}
+> ## Challenge: Python unpacking & Physics Logic
+>
+> **Python Unpacking:** In the code'fig, (ax_1, ax_2) = plt.subplots(1,2)', we use "tuple unpacking" to assign the figure and two separate plot axes to variables in one go.
+> **Physics  Logic:** For newcomers, remember the black dots are actual **Data** from ATLAS, while colored histograms are **Monte Carlo (MC)** simulations.We compare them to verify the $125 \text{Gev} Higgs signal matches theory! {: .challenge}
+
 
 > ## Exercise
 >

--- a/_episodes/04-higgs-search.md
+++ b/_episodes/04-higgs-search.md
@@ -411,11 +411,11 @@ ranges = [[80, 170]]
 bins = 24
 ```
 > ## Python Unpacking & Physics Logic
-> 
-> In the code `fig, (ax_1, ax_2) = plt.subplots(1, 2)`, we use 'tuple unpacking'. 
-> This is a very common pattern in Python when a function returns multiple values. 
-> Here, `subplots` returns a figure object and an array of axes. We "unpack" them 
-> into two separate variables, `ax_1` and `ax_2`, so we can plot different 
+>
+> In the code `fig, (ax_1, ax_2) = plt.subplots(1, 2)`, we use 'tuple unpacking'.
+> This is a very common pattern in Python when a function returns multiple values.
+> Here, `subplots` returns a figure object and an array of axes. We "unpack" them
+> into two separate variables, `ax_1` and `ax_2`, so we can plot different
 > distributions side-by-side.
 {: .callout}
 

--- a/_episodes/04-higgs-search.md
+++ b/_episodes/04-higgs-search.md
@@ -410,7 +410,7 @@ units = " [GeV]"
 ranges = [[80, 170]]
 bins = 24
 ```
-> ## Python Unpacking & Physics Logic
+> ##Python Unpacking & Physics Logic
 >
 > In the code `fig, (ax_1, ax_2) = plt.subplots(1, 2)`, we use 'tuple unpacking'.
 > This is a very common pattern in Python when a function returns multiple values.
@@ -419,7 +419,7 @@ bins = 24
 > distributions side-by-side.
 {: .callout}
 
->
+
 
 ```python
 fig, (ax_1, ax_2) = plt.subplots(1, 2)

--- a/_episodes/04-higgs-search.md
+++ b/_episodes/04-higgs-search.md
@@ -177,7 +177,6 @@ ax.hist(branches["data_A"]["m4l"])
 {: .output}
 
 ![m4lep_histogram_1]({{ page.root }}/fig/m4lep_histogram_1.png)
-
 > ## Exercise
 >
 > Make the histogram of the variable `m4l` for sample `mc_363490.llll`.
@@ -497,6 +496,11 @@ ax.legend(fontsize=18, frameon=False)
 ```
 
 ![m4lep_histogram_5]({{ page.root }}/fig/m4lep_histogram_5.png)
+
+> ## Physics Tip: The Higgs Signal
+> When looking at the invariant mass distribution, the peak at $125 \text{GeV}$  represents the reconstructed Higgs Boson.
+> **Data vs. MC:** The Black dots represent actual ATLAS experiment data, while the colored histograms are Monte Carlo (MC) Simulations. We compare them to see if our theoretical models match reality! {: .challenge}
+
 > ## Exercise
 >
 > Modify a bit the previous code to include the ticks and text, in the text and axis labels use latex to achieve the final plot.

--- a/_episodes/04-higgs-search.md
+++ b/_episodes/04-higgs-search.md
@@ -177,6 +177,7 @@ ax.hist(branches["data_A"]["m4l"])
 {: .output}
 
 ![m4lep_histogram_1]({{ page.root }}/fig/m4lep_histogram_1.png)
+>
 > ## Exercise
 >
 > Make the histogram of the variable `m4l` for sample `mc_363490.llll`.
@@ -401,7 +402,7 @@ for k in range(0, 3):
 ~~~
 {: .output}
 
-And then make a plot, actually, let's make 2 plots, with matplotlib we can add sub-plots to the figure, then, we will be able to compare the MC distribution without and with weights.
+And then make a plot, actually, let's make 2 plots, with matplotlib we can add sub-plots to the figure, then we will be able to compare the MC distribution without and with weights.
 
 ```python
 var_name = "m4l"
@@ -409,19 +410,16 @@ units = " [GeV]"
 ranges = [[80, 170]]
 bins = 24
 ```
-> ## Challenge: Python unpacking & Physics Logic
->
-> **Python Unpacking:** In the code `fig, (ax_1, ax_2) = plt.subplots(1, 2)`, we use `tuple unpacking` to assign the figure and two separate plot axes to variables in one go. For example:
->
-> ``` python
-> packed_data = (1, (2, 3))
-> a, (b, c) = packed_data
-> assert a == 1 and b == 2 and c == 3
-> ```
->
-> **Physics Logic:** For newcomers, remember the black dots are actual **Data** from ATLAS, while colored histograms are **Monte Carlo (MC)** simulations. We compare them to verify the 125 GeV Higgs signal matches theory!
-{: .challenge}
+> ## Python Unpacking & Physics Logic
+> 
+> In the code `fig, (ax_1, ax_2) = plt.subplots(1, 2)`, we use 'tuple unpacking'. 
+> This is a very common pattern in Python when a function returns multiple values. 
+> Here, `subplots` returns a figure object and an array of axes. We "unpack" them 
+> into two separate variables, `ax_1` and `ax_2`, so we can plot different 
+> distributions side-by-side.
+{: .callout}
 
+>
 
 ```python
 fig, (ax_1, ax_2) = plt.subplots(1, 2)
@@ -510,7 +508,6 @@ ax.legend(fontsize=18, frameon=False)
 
 ![m4lep_histogram_5]({{ page.root }}/fig/m4lep_histogram_5.png)
 
-> ## Challenge: Python unpacking & Physics Logic
 >
 
 

--- a/_episodes/04-higgs-search.md
+++ b/_episodes/04-higgs-search.md
@@ -409,6 +409,19 @@ units = " [GeV]"
 ranges = [[80, 170]]
 bins = 24
 ```
+> ## Challenge: Python unpacking & Physics Logic
+> 
+> **Python Unpacking:** In the code `fig, (ax_1, ax_2) = plt.subplots(1, 2)`, we use `tuple unpacking` to assign the figure and two separate plot axes to variables in one go. For example:
+>
+> ``` python
+> packed_data = (1, (2, 3))
+> a, (b, c) = packed_data
+> assert a == 1 and b == 2 and c == 3
+> ```
+> 
+> **Physics Logic:** For newcomers, remember the black dots are actual **Data** from ATLAS, while colored histograms are **Monte Carlo (MC)** simulations. We compare them to verify the 125 GeV Higgs signal matches theory!
+{: .challenge}
+
 
 ```python
 fig, (ax_1, ax_2) = plt.subplots(1, 2)
@@ -499,8 +512,6 @@ ax.legend(fontsize=18, frameon=False)
 
 > ## Challenge: Python unpacking & Physics Logic
 >
-> **Python Unpacking:** In the code'fig, (ax_1, ax_2) = plt.subplots(1,2)', we use "tuple unpacking" to assign the figure and two separate plot axes to variables in one go.
-> **Physics  Logic:** For newcomers, remember the black dots are actual **Data** from ATLAS, while colored histograms are **Monte Carlo (MC)** simulations.We compare them to verify the $125 \text{Gev} Higgs signal matches theory! {: .challenge}
 
 
 > ## Exercise

--- a/_episodes/04-higgs-search.md
+++ b/_episodes/04-higgs-search.md
@@ -410,7 +410,7 @@ ranges = [[80, 170]]
 bins = 24
 ```
 > ## Challenge: Python unpacking & Physics Logic
-> 
+>
 > **Python Unpacking:** In the code `fig, (ax_1, ax_2) = plt.subplots(1, 2)`, we use `tuple unpacking` to assign the figure and two separate plot axes to variables in one go. For example:
 >
 > ``` python
@@ -418,7 +418,7 @@ bins = 24
 > a, (b, c) = packed_data
 > assert a == 1 and b == 2 and c == 3
 > ```
-> 
+>
 > **Physics Logic:** For newcomers, remember the black dots are actual **Data** from ATLAS, while colored histograms are **Monte Carlo (MC)** simulations. We compare them to verify the 125 GeV Higgs signal matches theory!
 {: .challenge}
 


### PR DESCRIPTION
This PR addresses issue #127 by adding a challenge/callout box to the Higgs search module (Episode 4).
​As an MSc Physics student, I have added a "Physics Tip" to clarify the distinction between experimental Data (ATLAS points) and Monte Carlo (MC) simulations in the invariant mass plot. This helps students understand the significance of the 125 \text{ GeV} Higgs signal peak.
​Changes
​Inserted {: .challenge} block before the Data vs. MC exercise.
​Used LaTeX formatting for units and particle decay notation.
![1000162834](https://github.com/user-attachments/assets/86313b65-2c26-4622-88f6-45ad755a8250)
